### PR TITLE
Add adios2 upper bound

### DIFF
--- a/spack_repo/fenics/packages/fenics_dolfinx/package.py
+++ b/spack_repo/fenics/packages/fenics_dolfinx/package.py
@@ -74,7 +74,8 @@ class FenicsDolfinx(CMakePackage):
         depends_on("petsc+mpi+shared")
         depends_on("slepc")
 
-    depends_on("adios2@2.8.1:+mpi", when="@0.9: +adios2")
+    depends_on("adios2@:2.10", when="@:0.9 +adios2")
+    depends_on("adios2@2.8.1:", when="@0.9: +adios2")
     depends_on("adios2+mpi", when="+adios2")
     # This will need to be opened up in the future if we move away from locked
     # releases


### PR DESCRIPTION
Old versions don't work with 2.11 ADIOS2 CMake config.
