### PR TITLE
fix(fenics_basix): blas and lapack libs joined with semicolon

### DIFF
--- a/spack_repo/fenics/packages/fenics_basix/package.py
+++ b/spack_repo/fenics/packages/fenics_basix/package.py
@@ -51,6 +51,6 @@ class FenicsBasix(CMakePackage):
 
     def cmake_args(self):
         return [
-            "-DBLAS_LIBRARIES=" + self.spec["blas"].libs.joined(';'),
-            "-DLAPACK_LIBRARIES=" + self.spec["blas"].libs.joined(';'),
+            "-DBLAS_LIBRARIES=" + self.spec["blas"].libs.joined(";"),
+            "-DLAPACK_LIBRARIES=" + self.spec["blas"].libs.joined(";"),
         ]

--- a/spack_repo/fenics/packages/fenics_basix/package.py
+++ b/spack_repo/fenics/packages/fenics_basix/package.py
@@ -51,6 +51,6 @@ class FenicsBasix(CMakePackage):
 
     def cmake_args(self):
         return [
-            "-DBLAS_LIBRARIES=" + self.spec["blas"].libs.joined(),
-            "-DLAPACK_LIBRARIES=" + self.spec["blas"].libs.joined(),
+            "-DBLAS_LIBRARIES=" + self.spec["blas"].libs.joined(';'),
+            "-DLAPACK_LIBRARIES=" + self.spec["blas"].libs.joined(';'),
         ]


### PR DESCRIPTION
When building with spack with mkl replacement of blas and lapack, cmake receives e.g.:
-DBLAS_LIBRARIES=/path/libmkl_intel_lp64.so /path/libmkl_sequential.so /path/libmkl_core.so /lib/x86_64-linux-gnu/libm.so
-DLAPACK_LIBRARIES=/path/libmkl_intel_lp64.so /path/libmkl_sequential.so /path/libmkl_core.so /lib/x86_64-linux-gnu/libm.so
and fails since it needs column separated lists.
This PR fixes this.