### PR TITLE
Bump: upload-artifacts

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Upload log
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.spec }}-log
         path: log.xml


### PR DESCRIPTION
Raises warnings in CI runs, see [here](https://github.com/FEniCS/spack-fenics/actions/runs/24555585620).