### PR TITLE
Add a build_type variant to py-fenics-basix

### DIFF
--- a/spack_repo/fenics/packages/py_fenics_basix/package.py
+++ b/spack_repo/fenics/packages/py_fenics_basix/package.py
@@ -27,6 +27,14 @@ class PyFenicsBasix(PythonPackage):
     with default_args(deprecated=True):
         version("0.8.0", sha256="b299af82daf8fa3e4845e17f202491fe71b313bf6ab64c767a5287190b3dd7fe")
 
+    # CMake build type
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Developer"),
+    )
+
     variant("ufl", default=False, description="UFL support")
 
     depends_on("cxx", type="build")
@@ -66,6 +74,10 @@ class PyFenicsBasix(PythonPackage):
             depends_on(f"py-fenics-ufl@{ufl_ver}", type="run", when=f"@{ver}")
 
     def config_settings(self, spec, prefix):
-        return {"build.tool-args": f"-j{make_jobs}", "build.verbose": "true"}
+        return {
+            "build.tool-args": f"-j{make_jobs}",
+            "build.verbose": "true",
+            "cmake.build-type": spec.variants["build_type"].value,
+        }
 
     build_directory = "python"


### PR DESCRIPTION
`py-fenics-basix` compiles the `_basixcpp` nanobind extension through
scikit-build-core, but had no way to choose the CMake build type: its
`config_settings` passed only `build.tool-args` and `build.verbose`, so the
extension always took scikit-build-core's default.

That left it out of step with its own C++ library and with the DOLFINx Python
package — `fenics-basix` and `py-fenics-dolfinx` both expose the variant:

| package | `build_type` variant | passed to CMake |
|---|---|---|
| `fenics-basix` | yes | `CMakePackage` |
| `py-fenics-dolfinx` | yes | `"cmake.build-type": spec.variants["build_type"].value` |
| `py-fenics-basix` (before) | no | — |

DOLFINx asks for test builds to be `Developer` on both the C++ and the Python
side, which enables hardened checks — for basix that is
`-Wall -Werror -Wextra -pedantic`, `-g -O2`, and `_GLIBCXX_ASSERTIONS`
(or `_LIBCPP_HARDENING_MODE_DEBUG` on libc++), see
[`cpp/CMakeLists.txt`](https://github.com/FEniCS/basix/blob/main/cpp/CMakeLists.txt).
Until now `build_type=Developer` could be asked of `fenics-basix` but not of
`py-fenics-basix`, so the DOLFINx Spack CI built the library with those checks
and the bindings without them.

This adds the variant with the same values and default (`RelWithDebInfo`) as
`py-fenics-dolfinx`, and passes it through as `cmake.build-type`.

### Verification

Against spack `v1.2.2` with this repo:

```
$ spack spec py-fenics-basix@main build_type=Developer
 -   py-fenics-basix@main~ufl build_system=python_pip build_type=Developer ...

$ spack spec py-fenics-basix@main
 -   py-fenics-basix@main~ufl build_system=python_pip build_type=RelWithDebInfo ...

$ spack spec py-fenics-basix@main build_type=Nonsense
==> Error: invalid values for variant 'build_type' in package py-fenics-basix: 'Nonsense'
```

The default is unchanged, so no existing spec re-concretizes differently.

---

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.
