### PR TITLE
Split up workflow files

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -1,10 +1,9 @@
-name: test-spack
+name: test-package
 description: 'Builds a spack package from given spack-spec'
 inputs:
   spec:
     description: 'Spack spec syntax'
     required: true
-    type: string
   env-path:
     description: >-
       Directory for the Spack environment the build runs in. It is left in
@@ -29,21 +28,38 @@ runs:
   steps:
     - name: Install Spack requirements
       shell: sh
+      env:
+        SPEC: ${{ inputs.spec }}
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        apt-get -y update
-        apt-get install -y file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+        # clang shares the transaction rather than getting a step of its own.
+        # libclang-rt-18-dev is only a *recommend* of clang-18, so it has to
+        # be named once recommends are off: without it, any -fsanitize= link
+        # fails hunting for libclang_rt.asan-x86_64.a.
+        case "$SPEC" in
+          *clang@18*) clang="clang-18 libclang-rt-18-dev" ;;
+          *) clang="" ;;
+        esac
+        # Root inside the container, but not on a bare runner.
+        sudo=$(command -v sudo || true)
+        $sudo apt-get -y update
+        # --no-install-recommends drops 65 of 174 packages here - llvm-18-dev,
+        # manpages, the X libraries libgd drags in - and none of them are
+        # build inputs: spack builds its own make, curl, libffi and so on.
+        $sudo apt-get install -y --no-install-recommends \
+          file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release \
+          patch python3 tar unzip xz-utils zstd $clang
+        $sudo rm -rf /var/lib/apt/lists/*
 
     - name: Set up spack
-      uses: spack/setup-spack@v3
+      # Pinned to the commit v3 points at: spack_ref and packages_ref below
+      # are pinned, so leaving the action that consumes them on a mutable tag
+      # would be the one unpinned input to the build.
+      uses: spack/setup-spack@16b756799ede8b28951287f89bcd3fdb32ec1ca3 # v3
       with:
         spack_ref: v1.2.2
         # spack/spack-packages @ 2026-08-15
         packages_ref: f5642ce3dafc940e61f20a277e829f5edf5bd2d4
-
-    - name: Install clang-18
-      shell: sh
-      if: contains(inputs.spec, 'clang@18')
-      run: apt-get install -y clang-18
 
     # Written to the job environment rather than to this action's steps
     # alone: the names below are what 'spack mirror add' records in
@@ -129,14 +145,14 @@ runs:
         # pushing to it, a cache warmed for one solve is asked for different
         # hashes by the next. Binaries are still installed on a hash match.
         spack -e "$ENV_DIR" config add concretizer:reuse:false
-        spack -e "$ENV_DIR" concretize --deprecated -j 4
+        spack -e "$ENV_DIR" concretize --deprecated -j $(nproc)
 
     - name: Install
       shell: spack-bash {0}
       env:
         ENV_DIR: ${{ inputs.env-path }}
       run: >
-        spack -e "$ENV_DIR" install --deprecated -j 4
+        spack -e "$ENV_DIR" install --deprecated -j $(nproc)
         --log-format junit
         --log-file log.xml
 
@@ -162,7 +178,7 @@ runs:
     # two matrix entries tend to sit.
     - name: Name log artifact
       id: log
-      if: success() || failure()
+      if: ${{ !cancelled() }}
       shell: bash
       env:
         SPEC: ${{ inputs.spec }}
@@ -171,8 +187,9 @@ runs:
         echo "name=$slug" >> "$GITHUB_OUTPUT"
 
     - name: Upload log
-      if: success() || failure()
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.log.outputs.name }}-log
         path: log.xml
+        retention-days: 7

--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -5,6 +5,25 @@ inputs:
     description: 'Spack spec syntax'
     required: true
     type: string
+  env-path:
+    description: >-
+      Directory for the Spack environment the build runs in. It is left in
+      place for the rest of the job, so later steps can activate it; read the
+      path back from the env-path output rather than repeating it.
+    default: ./env
+  registry-user:
+    description: 'Username for the ghcr.io build cache.'
+    default: ${{ github.actor }}
+  registry-token:
+    description: >-
+      Token for the ghcr.io build cache; pass secrets.GITHUB_TOKEN. Exported
+      to the job as GHCR_TOKEN, since spack reads the mirror again in every
+      later step that installs.
+    required: true
+outputs:
+  env-path:
+    description: 'Directory of the Spack environment holding the built spec.'
+    value: ${{ inputs.env-path }}
 runs:
   using: "composite"
   steps:
@@ -26,10 +45,29 @@ runs:
       if: contains(inputs.spec, 'clang@18')
       run: apt-get install -y clang-18
 
+    # Written to the job environment rather than to this action's steps
+    # alone: the names below are what 'spack mirror add' records in
+    # mirrors.yaml, and spack resolves them again every time the caller's
+    # own 'spack install' steps consult the mirror. Not named GITHUB_*,
+    # both to avoid shadowing the runner's own variables and because the
+    # runner refuses to set that prefix through $GITHUB_ENV.
+    - name: Export build cache credentials
+      shell: bash
+      env:
+        REGISTRY_USER: ${{ inputs.registry-user }}
+        REGISTRY_TOKEN: ${{ inputs.registry-token }}
+      run: |
+        echo "::add-mask::$REGISTRY_TOKEN"
+        echo "GHCR_USER=$REGISTRY_USER" >> "$GITHUB_ENV"
+        echo "GHCR_TOKEN=$REGISTRY_TOKEN" >> "$GITHUB_ENV"
+
     - name: Add repos
       shell: spack-bash {0}
       run: |
-        spack repo add --name fenics $GITHUB_WORKSPACE/spack-fenics/spack_repo/fenics
+        # Found through the action's own location, so the caller is free to
+        # check the repo out wherever it likes.
+        repo_dir=$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)
+        spack repo add --name fenics "$repo_dir/spack_repo/fenics"
         spack config get repos
         spack repo list
 
@@ -40,7 +78,7 @@ runs:
          # access to a package's originating repo, and that one belongs to
          # dolfinx's CI, so pushing there 403s. It is also unpadded, so with
          # the padded tree below its binaries cannot be relocated either.
-         spack mirror add --unsigned --oci-username-variable GITHUB_USER --oci-password-variable GITHUB_TOKEN \
+         spack mirror add --unsigned --oci-username-variable GHCR_USER --oci-password-variable GHCR_TOKEN \
            push-buildcache oci://ghcr.io/fenics/spack-fenics-buildcache
          spack config add "packages:all:require:['os=ubuntu24.04','target=x86_64_v3']"
          # Pad the install tree so pushed binaries stay relocatable. Spack can
@@ -61,30 +99,44 @@ runs:
       shell: spack-bash {0}
       run: spack compiler find
 
+    # The spec and the environment path reach the shell as variables, not as
+    # expansions inside the script: GitHub substitutes an expansion before
+    # bash parses the line, so any shell metacharacter in a caller's spec
+    # would run as code.
     - name: Create env
       shell: spack-bash {0}
-      run: spack env create -d ./env
+      env:
+        ENV_DIR: ${{ inputs.env-path }}
+      run: spack env create -d "$ENV_DIR"
 
     - name: Add specs
       shell: spack-bash {0}
-      run: spack -e ./env add ${{ inputs.spec }}
+      env:
+        ENV_DIR: ${{ inputs.env-path }}
+        SPEC: ${{ inputs.spec }}
+      # $SPEC unquoted: a spec list is meant to split on whitespace here.
+      run: spack -e "$ENV_DIR" add $SPEC
 
     - name: Concretize
       shell: spack-bash {0}
+      env:
+        ENV_DIR: ${{ inputs.env-path }}
       run: |
-        spack -e ./env config add concretizer:unify:true
+        spack -e "$ENV_DIR" config add concretizer:unify:true
         # Keep the buildcache out of the solve. With reuse on (the default)
         # the concretizer prefers specs found in the mirrors, making hashes
         # depend on what the cache holds at that moment - and with 66 jobs
         # pushing to it, a cache warmed for one solve is asked for different
         # hashes by the next. Binaries are still installed on a hash match.
-        spack -e ./env config add concretizer:reuse:false
-        spack -e ./env concretize --deprecated -j 4
+        spack -e "$ENV_DIR" config add concretizer:reuse:false
+        spack -e "$ENV_DIR" concretize --deprecated -j 4
 
     - name: Install
       shell: spack-bash {0}
+      env:
+        ENV_DIR: ${{ inputs.env-path }}
       run: >
-        spack -e ./env install --deprecated -j 4
+        spack -e "$ENV_DIR" install --deprecated -j 4
         --log-format junit
         --log-file log.xml
 
@@ -98,13 +150,29 @@ runs:
         ${{ !cancelled() && (github.event_name != 'pull_request'
         || github.event.pull_request.head.repo.full_name == github.repository) }}
       shell: spack-bash {0}
+      env:
+        ENV_DIR: ${{ inputs.env-path }}
       run: >
-        spack -e ./env buildcache push --base-image ubuntu:24.04
+        spack -e "$ENV_DIR" buildcache push --base-image ubuntu:24.04
         --allow-missing --update-index push-buildcache
+
+    # Artifact names have to be unique within a run, and a raw spec makes for
+    # an unreadable one, so squash its punctuation into a slug. Not
+    # truncated: the tail of a spec is where the variants that distinguish
+    # two matrix entries tend to sit.
+    - name: Name log artifact
+      id: log
+      if: success() || failure()
+      shell: bash
+      env:
+        SPEC: ${{ inputs.spec }}
+      run: |
+        slug=$(printf '%s' "$SPEC" | tr -cs 'A-Za-z0-9.@+' '-' | sed 's/^-//; s/-$//')
+        echo "name=$slug" >> "$GITHUB_OUTPUT"
 
     - name: Upload log
       if: success() || failure()
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ inputs.spec }}-log
+        name: ${{ steps.log.outputs.name }}-log
         path: log.xml

--- a/.github/workflows/basix.yml
+++ b/.github/workflows/basix.yml
@@ -6,13 +6,10 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * MON" # weekly, Mondays 0200
 
 # Cancel superseded runs: a new commit on a pull request makes the
-# previous run's result irrelevant. Pushes to 'main' and scheduled runs
-# are left to finish. The group is per-workflow, so the packages do not
-# cancel each other.
+# previous run's result irrelevant. Pushes to 'main' are left to finish.
+# The group is per-workflow, so the packages do not cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/basix.yml
+++ b/.github/workflows/basix.yml
@@ -1,0 +1,88 @@
+name: basix
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * MON" # weekly, Mondays 0200
+
+# Cancel superseded runs: a new commit on a pull request makes the
+# previous run's result irrelevant. Pushes to 'main' and scheduled runs
+# are left to finish. The group is per-workflow, so the packages do not
+# cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GITHUB_USER: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  style-check:
+    uses: ./.github/workflows/style.yml
+
+  fenics-basix:
+    needs: style-check
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["main", "0.11", "0.10", "0.9", "0.8"]
+        spec: ["build_type=Developer %gcc@13", "build_type=Developer %clang@18"]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: spack-fenics
+      - uses: ./spack-fenics/.github/actions/test-package
+        with:
+          spec: fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+
+  py-fenics-basix:
+    needs: style-check
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["main", "0.11", "0.10", "0.9", "0.8"]
+        # Make sure fenics-basix and py-fenics-basix build with same compiler/ABI.
+        spec: ["+ufl %gcc@13 ^fenics-basix%gcc@13", "+ufl %clang@18 ^fenics-basix%clang@18"]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: spack-fenics
+      - uses: ./spack-fenics/.github/actions/test-package
+        with:
+          spec: py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+      - name: Run tests
+        if: ${{ matrix.version != '0.8' }}
+        shell: spack-bash {0}
+        run: |
+          spack env activate ./env
+          spack install --add py-pytest py-sympy py-pytest-xdist
+          spack stage py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+          spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+          python -m pytest -n auto test/
+      # NOTE: 0.8 has test_all_elements_included broken
+      - name: Run tests
+        if: ${{ matrix.version == '0.8' }}
+        shell: spack-bash {0}
+        run: |
+          spack env activate ./env
+          spack install --deprecated --add py-pytest py-sympy py-pytest-xdist
+          spack stage --deprecated py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+          spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+          python -m pytest -n auto -k "not test_all_elements_included" test/

--- a/.github/workflows/basix.yml
+++ b/.github/workflows/basix.yml
@@ -22,6 +22,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write
@@ -45,6 +48,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write
@@ -64,7 +70,7 @@ jobs:
         with:
           registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-      - name: Run tests
+      - name: Run tests (not 0.8)
         if: ${{ matrix.version != '0.8' }}
         shell: spack-bash {0}
         run: |
@@ -74,7 +80,7 @@ jobs:
           spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
           python -m pytest -n auto test/
       # NOTE: 0.8 has test_all_elements_included broken
-      - name: Run tests
+      - name: Run tests (0.8)
         if: ${{ matrix.version == '0.8' }}
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/basix.yml
+++ b/.github/workflows/basix.yml
@@ -1,4 +1,4 @@
-name: basix
+name: Basix
 
 on:
   push:

--- a/.github/workflows/basix.yml
+++ b/.github/workflows/basix.yml
@@ -14,10 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GITHUB_USER: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   style-check:
     uses: ./.github/workflows/style.yml
@@ -39,8 +35,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
 
   py-fenics-basix:
@@ -61,14 +59,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
       - name: Run tests
         if: ${{ matrix.version != '0.8' }}
         shell: spack-bash {0}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --add py-pytest py-sympy py-pytest-xdist
           spack stage py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
           spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
@@ -78,7 +78,7 @@ jobs:
         if: ${{ matrix.version == '0.8' }}
         shell: spack-bash {0}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --deprecated --add py-pytest py-sympy py-pytest-xdist
           spack stage --deprecated py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
           spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}

--- a/.github/workflows/dolfinx.yml
+++ b/.github/workflows/dolfinx.yml
@@ -6,13 +6,10 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * MON" # weekly, Mondays 0200
 
 # Cancel superseded runs: a new commit on a pull request makes the
-# previous run's result irrelevant. Pushes to 'main' and scheduled runs
-# are left to finish. The group is per-workflow, so the packages do not
-# cancel each other.
+# previous run's result irrelevant. Pushes to 'main' are left to finish.
+# The group is per-workflow, so the packages do not cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dolfinx.yml
+++ b/.github/workflows/dolfinx.yml
@@ -14,10 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GITHUB_USER: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   style-check:
     uses: ./.github/workflows/style.yml
@@ -45,8 +41,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }} py-fenics-ffcx catch2 cmake
       # FFCx compilation of poisson.py fails in ffcx/codegeneration/C/finite_element.py
       #
@@ -71,7 +69,7 @@ jobs:
           # not survive it).
           CXXFLAGS: ${{ contains(matrix.main_spec, 'clang@18') && '-Wno-unknown-warning-option' || '' }}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack load --first catch2 cmake fenics-dolfinx py-fenics-ffcx
           spack stage fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }}
           spack cd fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }}
@@ -112,8 +110,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
       # pytest@8.4 required for collision of [tool.pytest] and [tool.pytest.ini_options] since @9.0
       - name: Run tests (0.9)
@@ -126,7 +126,7 @@ jobs:
           # fixed in an old release, so pin it off for that combination.
           SKIP_REFINE: ${{ contains(matrix.spec, 'clang@18') && 'and not test_refine_interval' || '' }}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --deprecated --add py-pytest@8.4 py-scipy py-pytest-xdist ^python@${{ matrix.python-version }}
           spack stage py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
           spack cd py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
@@ -137,7 +137,7 @@ jobs:
         if: ${{ matrix.version != '0.8' && matrix.version != '0.9'}}
         shell: spack-bash {0}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --add py-pytest py-scipy py-pytest-xdist ^python@${{ matrix.python-version }}
           spack stage py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
           spack cd py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
@@ -155,7 +155,7 @@ jobs:
           # passes and still runs it.
           SKIP_EXACT: ${{ matrix.version != 'main' && 'and not test_matrix_assembly_rectangular' || '' }}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack stage py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
           spack cd py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
           python -m pytest -n auto -m "petsc4py or adios2" -k "not test_cffi_expression and not test_symmetry_interior_facet_assembly[mesh1] $SKIP_EXACT" python/test/unit

--- a/.github/workflows/dolfinx.yml
+++ b/.github/workflows/dolfinx.yml
@@ -22,6 +22,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write
@@ -30,7 +33,7 @@ jobs:
       matrix:
         # NOTE: clang sometimes likes stub or Intel MPI. Force MPI implementations.
         version: ["main", "0.11", "0.10", "0.9", "0.8"]
-        main_spec: ["build_type=Developer %%c,cxx=clang@18 ^mpich", "build_type=Developer partitioners=kahip,parmetis,scotch +petsc +slepc +adios2 %%gcc@13 ^openmpi"]
+        spec: ["build_type=Developer %%c,cxx=clang@18 ^mpich", "build_type=Developer partitioners=kahip,parmetis,scotch +petsc +slepc +adios2 %%gcc@13 ^openmpi"]
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
@@ -45,7 +48,7 @@ jobs:
         uses: ./spack-fenics/.github/actions/test-package
         with:
           registry-token: ${{ secrets.GITHUB_TOKEN }}
-          spec: fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }} py-fenics-ffcx catch2 cmake
+          spec: fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} py-fenics-ffcx catch2 cmake
       # FFCx compilation of poisson.py fails in ffcx/codegeneration/C/finite_element.py
       #
       # No 'spack build-env' here: it rebuilds the *build* environment, which
@@ -59,20 +62,20 @@ jobs:
         env:
           # The compilers are externals, so not loadable specs; name them so
           # the tests use the same compiler as the library they link against.
-          CC: ${{ contains(matrix.main_spec, 'clang@18') && 'clang-18' || 'gcc' }}
-          CXX: ${{ contains(matrix.main_spec, 'clang@18') && 'clang++-18' || 'g++' }}
+          CC: ${{ contains(matrix.spec, 'clang@18') && 'clang-18' || 'gcc' }}
+          CXX: ${{ contains(matrix.spec, 'clang@18') && 'clang++-18' || 'g++' }}
           # dolfinx's cpp/test adds -Wno-c2y-extensions for any Clang, but it
           # only exists from Clang 19. Harmless until build-env went, since
           # spack's wrapper drops -Werror; now fatal. -Wno-unknown-warning-
           # option survives dolfinx's later -Werror, which promotes enabled
           # warnings but does not re-enable disabled ones (-Wno-error= would
           # not survive it).
-          CXXFLAGS: ${{ contains(matrix.main_spec, 'clang@18') && '-Wno-unknown-warning-option' || '' }}
+          CXXFLAGS: ${{ contains(matrix.spec, 'clang@18') && '-Wno-unknown-warning-option' || '' }}
         run: |
           spack env activate ${{ steps.spack.outputs.env-path }}
           spack load --first catch2 cmake fenics-dolfinx py-fenics-ffcx
-          spack stage fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }}
-          spack cd fenics-dolfinx@${{ matrix.version }} ${{ matrix.main_spec }}
+          spack stage fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }}
+          spack cd fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }}
           cmake -B build/test/ -S cpp/test/ -DCMAKE_BUILD_TYPE=Developer
           cmake --build build/test
           cd build/test
@@ -83,6 +86,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dolfinx.yml
+++ b/.github/workflows/dolfinx.yml
@@ -1,4 +1,4 @@
-name: 🤖
+name: dolfinx
 
 on:
   push:
@@ -11,7 +11,8 @@ on:
 
 # Cancel superseded runs: a new commit on a pull request makes the
 # previous run's result irrelevant. Pushes to 'main' and scheduled runs
-# are left to finish.
+# are left to finish. The group is per-workflow, so the packages do not
+# cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -22,48 +23,7 @@ env:
 
 jobs:
   style-check:
-    name: ✨
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-      - name: Fetch Spack CI scripts
-        uses: actions/checkout@v7
-        with:
-          repository: spack/spack
-          ref: v1.2.2
-          path: spack-core
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.github/workflows/requirements/style/requirements.txt
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/pyproject.toml
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.ci/style_check.sh
-      - run: pip install -r requirements.txt
-      - run: chmod +x style_check.sh
-      - run: ./style_check.sh HEAD^
-
-  fenics-basix:
-    needs: style-check
-    runs-on: ubuntu-24.04
-    container: ubuntu:24.04
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["main", "0.11", "0.10", "0.9", "0.8"]
-        spec: ["build_type=Developer %gcc@13", "build_type=Developer %clang@18"]
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
-        with:
-          spec: fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
+    uses: ./.github/workflows/style.yml
 
   fenics-dolfinx:
     needs: style-check
@@ -123,69 +83,6 @@ jobs:
           cd build/test
           ctest -V --output-on-failure -R unittests_np_1
           ctest -V --output-on-failure -R unittests_np_3
-
-
-  fenics-ufcx:
-    needs: style-check
-    runs-on: ubuntu-24.04
-    container: ubuntu:24.04
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["main", "0.11", "0.10", "0.9", "0.8"]
-        spec: ["%gcc@13"]
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
-        with:
-          spec: fenics-ufcx@${{ matrix.version }} ${{ matrix.spec }}
-
-  py-fenics-basix:
-    needs: style-check
-    runs-on: ubuntu-24.04
-    container: ubuntu:24.04
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["main", "0.11", "0.10", "0.9", "0.8"]
-        # Make sure fenics-basix and py-fenics-basix build with same compiler/ABI.
-        spec: ["+ufl %gcc@13 ^fenics-basix%gcc@13", "+ufl %clang@18 ^fenics-basix%clang@18"]
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
-        with:
-          spec: py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-      - name: Run tests
-        if: ${{ matrix.version != '0.8' }}
-        shell: spack-bash {0}
-        run: |
-          spack env activate ./env
-          spack install --add py-pytest py-sympy py-pytest-xdist
-          spack stage py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-          spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-          python -m pytest -n auto test/
-      # NOTE: 0.8 has test_all_elements_included broken
-      - name: Run tests
-        if: ${{ matrix.version == '0.8' }}
-        shell: spack-bash {0}
-        run: |
-          spack env activate ./env
-          spack install --deprecated --add py-pytest py-sympy py-pytest-xdist
-          spack stage --deprecated py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-          spack cd py-fenics-basix@${{ matrix.version }} ${{ matrix.spec }}
-          python -m pytest -n auto -k "not test_all_elements_included" test/
 
   py-fenics-dolfinx:
     needs: style-check
@@ -266,63 +163,3 @@ jobs:
           spack cd py-fenics-dolfinx@${{ matrix.version }} ${{ matrix.spec }} ^python@${{ matrix.python-version }}
           python -m pytest -n auto -m "petsc4py or adios2" -k "not test_cffi_expression and not test_symmetry_interior_facet_assembly[mesh1] $SKIP_EXACT" python/test/unit
           mpiexec -n 3 python -m pytest -m "petsc4py or adios2" -k "not test_cffi_expression and not test_symmetry_interior_facet_assembly[mesh1] $SKIP_EXACT" python/test/unit
-
-  py-fenics-ffcx:
-    needs: style-check
-    runs-on: ubuntu-24.04
-    container: ubuntu:24.04
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["main", "0.11", "0.10", "0.9", "0.8"]
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          path: spack-fenics
-      # NOTE: Python built with GCC, otherwise cffi can try for an odd compiler.
-      - uses: ./spack-fenics/.github/actions/test-package
-        with:
-          spec: py-fenics-ffcx@${{ matrix.version }} ^python %%gcc@13 py-numba
-      # NOTE: ffcx version 0.8 currently broken
-      - name: Run tests
-        if: ${{ matrix.version != '0.8' }}
-        shell: spack-bash {0}
-        run: |
-          spack env activate ./env
-          spack install --add py-pytest py-sympy py-pytest-xdist
-          spack stage py-fenics-ffcx@${{ matrix.version }}
-          spack cd py-fenics-ffcx@${{ matrix.version }}
-          python -m pytest -n auto test/
-
-  py-fenics-ufl:
-    needs: style-check
-    runs-on: ubuntu-24.04
-    container: ubuntu:24.04
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["main", "2025.2", "2025.1", "2024.2", "2024.1"]
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
-        with:
-          spec: py-fenics-ufl@${{ matrix.version }}
-      # NOTE: Reference counting changed in Python 3.14, leading to test failure.
-      - name: Run tests
-        shell: spack-bash {0}
-        run: |
-          spack env activate ./env
-          spack install --add py-pytest py-pytest-xdist
-          spack stage py-fenics-ufl@${{ matrix.version }}
-          spack cd py-fenics-ufl@${{ matrix.version }}
-          python -m pytest -n auto -k "not test_strip_form_arguments_strips_data_refs" test/

--- a/.github/workflows/dolfinx.yml
+++ b/.github/workflows/dolfinx.yml
@@ -1,4 +1,4 @@
-name: dolfinx
+name: DOLFINx
 
 on:
   push:

--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -24,6 +24,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write
@@ -31,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         version: ["main", "0.11", "0.10", "0.9", "0.8"]
-        spec: ["%gcc@13"]
 
     steps:
       - uses: actions/checkout@v7
@@ -41,12 +43,15 @@ jobs:
         uses: ./spack-fenics/.github/actions/test-package
         with:
           registry-token: ${{ secrets.GITHUB_TOKEN }}
-          spec: fenics-ufcx@${{ matrix.version }} ${{ matrix.spec }}
+          spec: fenics-ufcx@${{ matrix.version }} %gcc@13
 
   py-fenics-ffcx:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -16,10 +16,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GITHUB_USER: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   style-check:
     uses: ./.github/workflows/style.yml
@@ -41,8 +37,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: fenics-ufcx@${{ matrix.version }} ${{ matrix.spec }}
 
   py-fenics-ffcx:
@@ -62,15 +60,17 @@ jobs:
         with:
           path: spack-fenics
       # NOTE: Python built with GCC, otherwise cffi can try for an odd compiler.
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: py-fenics-ffcx@${{ matrix.version }} ^python %%gcc@13 py-numba
       # NOTE: ffcx version 0.8 currently broken
       - name: Run tests
         if: ${{ matrix.version != '0.8' }}
         shell: spack-bash {0}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --add py-pytest py-sympy py-pytest-xdist
           spack stage py-fenics-ffcx@${{ matrix.version }}
           spack cd py-fenics-ffcx@${{ matrix.version }}

--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -8,13 +8,10 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * MON" # weekly, Mondays 0200
 
 # Cancel superseded runs: a new commit on a pull request makes the
-# previous run's result irrelevant. Pushes to 'main' and scheduled runs
-# are left to finish. The group is per-workflow, so the packages do not
-# cancel each other.
+# previous run's result irrelevant. Pushes to 'main' are left to finish.
+# The group is per-workflow, so the packages do not cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -1,4 +1,4 @@
-name: ffcx
+name: FFCx
 
 # fenics-ufcx is the C interface from the FFCx repo, so it lives here with
 # py-fenics-ffcx rather than in a workflow of its own.

--- a/.github/workflows/ffcx.yml
+++ b/.github/workflows/ffcx.yml
@@ -1,0 +1,80 @@
+name: ffcx
+
+# fenics-ufcx is the C interface from the FFCx repo, so it lives here with
+# py-fenics-ffcx rather than in a workflow of its own.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * MON" # weekly, Mondays 0200
+
+# Cancel superseded runs: a new commit on a pull request makes the
+# previous run's result irrelevant. Pushes to 'main' and scheduled runs
+# are left to finish. The group is per-workflow, so the packages do not
+# cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GITHUB_USER: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  style-check:
+    uses: ./.github/workflows/style.yml
+
+  fenics-ufcx:
+    needs: style-check
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["main", "0.11", "0.10", "0.9", "0.8"]
+        spec: ["%gcc@13"]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: spack-fenics
+      - uses: ./spack-fenics/.github/actions/test-package
+        with:
+          spec: fenics-ufcx@${{ matrix.version }} ${{ matrix.spec }}
+
+  py-fenics-ffcx:
+    needs: style-check
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["main", "0.11", "0.10", "0.9", "0.8"]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: spack-fenics
+      # NOTE: Python built with GCC, otherwise cffi can try for an odd compiler.
+      - uses: ./spack-fenics/.github/actions/test-package
+        with:
+          spec: py-fenics-ffcx@${{ matrix.version }} ^python %%gcc@13 py-numba
+      # NOTE: ffcx version 0.8 currently broken
+      - name: Run tests
+        if: ${{ matrix.version != '0.8' }}
+        shell: spack-bash {0}
+        run: |
+          spack env activate ./env
+          spack install --add py-pytest py-sympy py-pytest-xdist
+          spack stage py-fenics-ffcx@${{ matrix.version }}
+          spack cd py-fenics-ffcx@${{ matrix.version }}
+          python -m pytest -n auto test/

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   style-check:
-    name: ✨
+    name: Spack style check ✨
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v7

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,26 +5,46 @@ name: ✨
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   style-check:
     name: Spack style check ✨
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 2
-      - name: Fetch Spack CI scripts
-        uses: actions/checkout@v7
-        with:
-          repository: spack/spack
-          ref: v1.2.2
-          path: spack-core
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.github/workflows/requirements/style/requirements.txt
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/pyproject.toml
-      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.ci/style_check.sh
+          # Full history: the diff base below is the ref's previous tip, which
+          # is an arbitrary distance back.
+          fetch-depth: 0
+      - name: Fetch Spack style config and check script
+        run: |
+          # -O on every download. wget does not overwrite an existing file, it
+          # writes 'name.1' alongside it, and the repo root already holds a
+          # pyproject.toml - so without -O, ruff below silently picks up this
+          # repo's copy instead of the config being fetched here.
+          url=https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4
+          wget -O requirements.txt $url/.github/workflows/requirements/style/requirements.txt
+          wget -O pyproject.toml $url/pyproject.toml
+          wget -O style_check.sh $url/.ci/style_check.sh
       - run: pip install -r requirements.txt
-      - run: chmod +x style_check.sh
-      - run: ./style_check.sh HEAD^
+      - name: Run style check
+        env:
+          # A push can carry several commits, and HEAD^ would check only the
+          # tip; github.event.before is the ref's previous tip, so the whole
+          # push is covered. It is unset on pull_request - where HEAD is the
+          # merge commit, making HEAD^ the base and already correct - and
+          # points at nothing after a force push or a branch's first push.
+          BEFORE: ${{ github.event.before }}
+        run: |
+          if [ -n "$BEFORE" ] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            base=$BEFORE
+          else
+            base=HEAD^
+          fi
+          sh style_check.sh "$base"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,30 @@
+name: ✨
+
+# Reusable: each per-package workflow calls this and gates its build matrix
+# on it, since 'needs:' cannot reach across workflow files.
+on:
+  workflow_call:
+
+jobs:
+  style-check:
+    name: ✨
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - name: Fetch Spack CI scripts
+        uses: actions/checkout@v7
+        with:
+          repository: spack/spack
+          ref: v1.2.2
+          path: spack-core
+      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.github/workflows/requirements/style/requirements.txt
+      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/pyproject.toml
+      - run: wget https://raw.githubusercontent.com/spack/spack-packages/f5642ce3dafc940e61f20a277e829f5edf5bd2d4/.ci/style_check.sh
+      - run: pip install -r requirements.txt
+      - run: chmod +x style_check.sh
+      - run: ./style_check.sh HEAD^

--- a/.github/workflows/ufl.yml
+++ b/.github/workflows/ufl.yml
@@ -1,0 +1,55 @@
+name: ufl
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * MON" # weekly, Mondays 0200
+
+# Cancel superseded runs: a new commit on a pull request makes the
+# previous run's result irrelevant. Pushes to 'main' and scheduled runs
+# are left to finish. The group is per-workflow, so the packages do not
+# cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GITHUB_USER: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  style-check:
+    uses: ./.github/workflows/style.yml
+
+  py-fenics-ufl:
+    needs: style-check
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["main", "2025.2", "2025.1", "2024.2", "2024.1"]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: spack-fenics
+      - uses: ./spack-fenics/.github/actions/test-package
+        with:
+          spec: py-fenics-ufl@${{ matrix.version }}
+      # NOTE: Reference counting changed in Python 3.14, leading to test failure.
+      - name: Run tests
+        shell: spack-bash {0}
+        run: |
+          spack env activate ./env
+          spack install --add py-pytest py-pytest-xdist
+          spack stage py-fenics-ufl@${{ matrix.version }}
+          spack cd py-fenics-ufl@${{ matrix.version }}
+          python -m pytest -n auto -k "not test_strip_form_arguments_strips_data_refs" test/

--- a/.github/workflows/ufl.yml
+++ b/.github/workflows/ufl.yml
@@ -1,4 +1,4 @@
-name: ufl
+name: UFL
 
 on:
   push:

--- a/.github/workflows/ufl.yml
+++ b/.github/workflows/ufl.yml
@@ -6,13 +6,10 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * MON" # weekly, Mondays 0200
 
 # Cancel superseded runs: a new commit on a pull request makes the
-# previous run's result irrelevant. Pushes to 'main' and scheduled runs
-# are left to finish. The group is per-workflow, so the packages do not
-# cancel each other.
+# previous run's result irrelevant. Pushes to 'main' are left to finish.
+# The group is per-workflow, so the packages do not cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ufl.yml
+++ b/.github/workflows/ufl.yml
@@ -14,10 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GITHUB_USER: ${{ github.actor }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   style-check:
     uses: ./.github/workflows/style.yml
@@ -38,14 +34,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: spack-fenics
-      - uses: ./spack-fenics/.github/actions/test-package
+      - id: spack
+        uses: ./spack-fenics/.github/actions/test-package
         with:
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
           spec: py-fenics-ufl@${{ matrix.version }}
       # NOTE: Reference counting changed in Python 3.14, leading to test failure.
       - name: Run tests
         shell: spack-bash {0}
         run: |
-          spack env activate ./env
+          spack env activate ${{ steps.spack.outputs.env-path }}
           spack install --add py-pytest py-pytest-xdist
           spack stage py-fenics-ufl@${{ matrix.version }}
           spack cd py-fenics-ufl@${{ matrix.version }}

--- a/.github/workflows/ufl.yml
+++ b/.github/workflows/ufl.yml
@@ -22,6 +22,9 @@ jobs:
     needs: style-check
     runs-on: ubuntu-24.04
     container: ubuntu:24.04
+    # Warm-cache jobs peak around an hour; this is headroom for a cold
+    # cache while still catching a hang well before the 6h default.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Splits the single `spack-matrix.yml` (`🤖`) workflow into one workflow per FEniCS package, and hardens the `test-package` composite action they all share.

| Workflow | Jobs |
| --- | --- |
| `basix.yml` | `fenics-basix`, `py-fenics-basix` |
| `dolfinx.yml` | `fenics-dolfinx`, `py-fenics-dolfinx` |
| `ffcx.yml` | `fenics-ufcx`, `py-fenics-ffcx` |
| `ufl.yml` | `py-fenics-ufl` |
| `style.yml` | reusable, called by each of the above |

`fenics-ufcx` is the C interface from the FFCx repo, so it sits with `py-fenics-ffcx` rather than in a workflow of its own.

The split gives each package its own status and its own concurrency group, so a new commit cancels only the package it supersedes instead of the whole 66-job matrix. `needs:` cannot reach across workflow files, so the style check becomes a reusable `workflow_call` workflow that each package workflow gates its matrix on. The weekly Monday cron is dropped.

## The style check was running the wrong config

Worth a close look, since it changes what CI enforces.

`style.yml` fetched spack-packages' `pyproject.toml` with a bare `wget`. wget does not overwrite an existing file — it writes `pyproject.toml.1` alongside it — and the repo root already holds a `pyproject.toml`, so the download was inert and `ruff` read this repo's copy instead. That copy is a stale one from **spack/spack**, not spack-packages, and it enables a weaker rule set:

| | repo copy (what ran) | spack-packages (intended) |
| --- | --- | --- |
| `lint.extend-select` | `["I"]` | `["E", "I", "W"]` |
| `lint.ignore` | `E731, E203, F403, F811` | `E731, F403, F811` |
| `format.line-ending` | unset | `"lf"` |

Fixed by downloading with `-O`. `spack_repo/` is clean under both configs with ruff 0.15.11, so no new violations appear — but the gate is now stricter than it was.

Two related fixes while in there:

- The `spack/spack@v1.2.2` checkout is dropped. `style_check.sh` uses only `git`, `grep` and `ruff`, and nothing put `spack-core` on `PATH` — it was a full clone per style job, four times per push.
- The diff base is `github.event.before` rather than `HEAD^`, so a push carrying several commits is checked whole instead of just its tip. It falls back to `HEAD^` when that SHA is unusable: unset on `pull_request` (where `HEAD` is the merge commit, making `HEAD^` the base and already correct), and dangling after a force push or a branch's first push.

The root `pyproject.toml` is left in place — CI no longer reads it, but it is still what local `ruff` picks up, and whether it should be deleted or refreshed is a call about local tooling rather than this PR.

## `test-package` action

- **Spec no longer interpolated into a shell script.** `${{ inputs.spec }}` is substituted before bash parses the line, so a metacharacter in a caller's spec would execute. It now arrives as `$SPEC`, unquoted so the spec list still splits on whitespace. Same for the environment path.
- **The fenics repo is located via `$GITHUB_ACTION_PATH`** instead of a hardcoded `$GITHUB_WORKSPACE/spack-fenics`, so the caller's `path:` is no longer baked into the action.
- **Build cache credentials are declared inputs** (`registry-user`, `registry-token`) rather than an undeclared dependency on workflow-level `env:`. They are exported as `GHCR_USER`/`GHCR_TOKEN` — job-wide, because spack resolves those names again in every later `spack install` that consults the mirror, and because the runner refuses to set `GITHUB_*` through `$GITHUB_ENV`. The four duplicated `env:` blocks are gone.
- **The environment path is an input and an output** (`env-path`, default `./env`), so callers reference `steps.spack.outputs.env-path` instead of repeating a magic string.
- **Log artifacts get a slug** rather than the raw spec, which produced names like `py-fenics-dolfinx@0.11 build_type=Developer +petsc4py ... ^python@3.13-log`. Not truncated — the variants that distinguish two matrix entries sit at the tail.
- **One apt transaction** instead of two, with `--no-install-recommends` (174 packages → 109) and `DEBIAN_FRONTEND=noninteractive`. `libclang-rt-18-dev` is named explicitly: it is only a *recommend* of `clang-18`, and without it any `-fsanitize=` link fails looking for `libclang_rt.asan-x86_64.a`. Verified in an `ubuntu:24.04` container that gcc, g++, gfortran, clang-18 and clang++-18 all still compile and link, with and without the clang branch.
- `spack/setup-spack` is pinned to the commit `v3` points at, matching the already-pinned `spack_ref` and `packages_ref`.
- `-j 4` → `-j $(nproc)`; `success() || failure()` → `!cancelled()`; `retention-days: 7` on logs.

## Job hygiene

`timeout-minutes: 240` on the build jobs and `15` on style. The slowest warm-cache job in a recent successful DOLFINx run was 57 min, so this leaves room for a cold-cache rebuild while cutting 2h off the 6h default. `permissions: contents: read` on the reusable style workflow, which previously inherited the repository default.

Naming: basix's two identically-named `Run tests` steps are now `(not 0.8)` / `(0.8)`; dolfinx's `main_spec` matrix key is `spec`, matching the job below it; ffcx's one-value `spec` axis is inlined.

## Not covered

Nothing here changes which specs are built or tested — the matrices, variants, deselected tests and the netlib-over-openblas pin all carry over unchanged.
