### PR TITLE
Fix inaccuracies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This Spack package repository contains Spack packages only for the FEniCS
 Project components. Using `spack repo add` it can be overlaid onto any complete
-upstream package repository. Its FEniCS component package will then take
-precedence over the upstream package repository.
+upstream package repository. Its FEniCS component packages will then take
+precedence over those in the upstream package repository.
 
 ## Instructions
 
@@ -85,14 +85,14 @@ To build C++ applications using Spack's build environment (e.g. when it used
 special compilers to build fenics-dolfinx):
 
     spack load cmake fenics-dolfinx py-fenics-ffcx
-    spack build-spec --dump spack-build-env.sh fenics-dolfinx
+    spack build-env --dump spack-build-env.sh fenics-dolfinx
     source spack-build-env.sh
-    # Execute e.g. cmake, should use Spack's compiler-wrapper 
+    # Execute e.g. cmake, should use Spack's compiler-wrapper
 
 ## Developer notes
 
 Diffing against an upstream `builtin` package set:
 
-    export OTHER_PACKAGES_DIR=/path/to/spack-packages/repos/spack_repo/builtin/packages 
-    cd spack-fenics/spack_repo/fenics/package
-    for dir in */; do; git --no-pager diff --no-index $OTHER_PACKAGES_DIR/$dir $dir; done;
+    export OTHER_PACKAGES_DIR=/path/to/spack-packages/repos/spack_repo/builtin/packages
+    cd spack-fenics/spack_repo/fenics/packages
+    for dir in */; do git --no-pager diff --no-index "$OTHER_PACKAGES_DIR/$dir" "$dir"; done


### PR DESCRIPTION
## Summary
- `spack build-spec` isn't a real command; the correct one is `spack build-env --dump <file> <spec>`.
- The dev-notes diff loop `cd`s into `spack_repo/fenics/package`, which doesn't exist — it's `packages`.
- `for dir in */; do; ...; done;` uses zsh's `do;` syntax; it's a bash syntax error. Fixed and quoted the paths while there.
- Trailing whitespace on two lines, and "component package"/"the upstream package repository" corrected to plural (there are multiple FEniCS packages overlaying multiple upstream packages).

Not included: a few accuracy items I found but am holding for the maintainer to weigh in on before wording them (the `kahip` override not being mentioned in the "only FEniCS components" line, the "last three x versions" count vs. the four actually built, the stated reason for skipping `py-fenics-dolfinx@0.8` tests, and a caveat that `spack build-env` needs a locally-built spec rather than one from the buildcache).

## Test plan
- [x] Verified `spack build-env --dump` is the real flag (`spack/cmd/common/env_utility.py`)
- [x] Verified `spack_repo/fenics/packages/` is the actual directory name
- [x] Verified the corrected loop parses under `bash -n`
- [x] `grep -nE ' +$' README.md` is now empty