### PR TITLE
Require boost@1.81: for fenics-dolfinx@main

### DIFF
--- a/spack_repo/fenics/packages/fenics_dolfinx/package.py
+++ b/spack_repo/fenics/packages/fenics_dolfinx/package.py
@@ -72,6 +72,7 @@ class FenicsDolfinx(CMakePackage):
     depends_on("mpi")
     # HDF5Interface.cpp #if H5_VERSION_GE are not precise enough.
     depends_on("hdf5+mpi@1.12:")
+    depends_on("boost@1.81:", when="@main")
     depends_on("boost@1.70:")
     depends_on("boost@1.70:+timer", when="@:0.9")
     depends_on("pugixml")


### PR DESCRIPTION
Add a minimum boost version constraint of 1.81 for `fenics-dolfinx@main`, matching the descending-version ordering convention already used for other constraints in this package (e.g. cmake).

Used Claude Sonnet 5.0.